### PR TITLE
(PROBLEM-1192) Fixing a bug which does not render images in the solution markdown

### DIFF
--- a/1192. Critical Connections in a Network/solution.md
+++ b/1192. Critical Connections in a Network/solution.md
@@ -31,22 +31,22 @@ We look for its label and min it with the current node's ORIGINAL label (emphasi
 Let say we have the below graph as input and we wanna find out its critical edges. We know the only critical edge it has is the one going out of the triangle.
 Lets assume the the node marked S is the source.
 
-![Graph](images/IMG_0255.png?raw=true "Graph")
+![Graph](images/IMG_0255.PNG?raw=true "Graph")
 
 We discover the node and mark its disovery time as 0 and label it as 0 as well initially.
 
-![Graph1](images/IMG_0246.png?raw=true "Graph1")
+![Graph1](images/IMG_0246.PNG?raw=true "Graph1")
 
 
 Then, we move onto the next node. Since it has not been disovered yet too, we label it 1 with disovery time 1. Denoted as 1/1.
 Similary, we go to the next node as 2/2.
 
 
-![Graph2](images/IMG_0247.png?raw=true "Graph2")
+![Graph2](images/IMG_0247.PNG?raw=true "Graph2")
 
 
 Then we move onto the last node 3/3
-![Graph](images/IMG_0248.png?raw=true "Graph")
+![Graph3](images/IMG_0248.PNG?raw=true "Graph3")
 
 
 
@@ -54,10 +54,10 @@ Since, 3/3 has no neighbours (other than the caller node of course), it backtrac
 Now, 2 evaluates the edege 2-3. 
 The low link value of 3 (the node who backtracked) is higher than its low link value. This must mean that 3 did not run into any nodes discovered before it (node 2). So the edge 2-3 must be critical being the only link to the node labelled 3. We mark it critical.
 
-![Graph](images/IMG_0249.png?raw=true "Graph")
+![Graph4](images/IMG_0249.PNG?raw=true "Graph4")
 
 
-![Graph](images/IMG_0250.png?raw=true "Graph")
+![Graph5](images/IMG_0250.PNG?raw=true)
 
 
 
@@ -69,20 +69,20 @@ lowlink(node2) = min( 2, 0 )
 lowlink(node2) = 0
 So, node 2 will update its lowlink value as 0.
 
-![Graph](images/IMG_0251.png?raw=true "Graph")
+![Graph6](images/IMG_0251.PNG?raw=true)
 
 
 The graph look like this at this point.
-![Graph](images/IMG_0252.png?raw=true "Graph")
+![Graph7](images/IMG_0252.PNG?raw=true)
 
 
 
 Node 1 mins its lowlink value with node 2. Because node 2's lowlink is lower than or equal to (in this case equal to) to its own low link, then there must another way to reach node 2 from node 1 other than the direct link. We do not mark edge 1-2 critical.
-![Graph](images/IMG_0253.png?raw=true "Graph")
+![Graph8](images/IMG_0253.PNG?raw=true)
 
 
 Similary, edge 0-1 is not critical either.
-![Graph](images/IMG_0254.png?raw=true "Graph")
+![Graph9](images/IMG_0254.PNG?raw=true)
 
 
 The algorithm finishes up having found only one critical edge (edge 2 - 3) as expected.


### PR DESCRIPTION
This is because we have windows PC locally which is case insensitive in filenames. But github is probably rendering it on a linux system which is case sensitive. So .png is not the same as .PNG for github.